### PR TITLE
Fix use of Time model serialization

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -11,9 +11,13 @@ type Time struct {
 	T time.Time
 }
 
+// rfc3339Milli is like time.RFC3339Nano, but with millisecond precision, and fractional seconds do not have trailing
+// zeros removed.
+const rfc3339Milli = "2006-01-02T15:04:05.000Z07:00"
+
 // Value satisfies driver.Valuer interface.
 func (t *Time) Value() (driver.Value, error) {
-	return t.T.Format(time.RFC3339Nano), nil
+	return t.T.UTC().Format(rfc3339Milli), nil
 }
 
 // Scan satisfies sql.Scanner interface.
@@ -27,12 +31,12 @@ func (t *Time) Scan(src any) error {
 		return errors.Newf("error scanning time, got %+v", src)
 	}
 
-	parsedT, err := time.Parse(time.RFC3339Nano, s)
+	parsedT, err := time.Parse(rfc3339Milli, s)
 	if err != nil {
 		return err
 	}
 
-	t.T = parsedT
+	t.T = parsedT.UTC()
 
 	return nil
 }

--- a/sql/migrations/1667829184-init.up.sql
+++ b/sql/migrations/1667829184-init.up.sql
@@ -1,9 +1,9 @@
 create table foo (
   id integer primary key,
-  created text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-  updated text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+  created text not null default (strftime('%Y-%m-%dT%H:%M:%fZ')),
+  updated text not null default (strftime('%Y-%m-%dT%H:%M:%fZ'))
 ) strict;
 
 create trigger foo_updated_timestamp after update on foo begin
-  update foo set updated = (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) where id = old.id;
+  update foo set updated = strftime('%Y-%m-%dT%H:%M:%fZ') where id = old.id;
 end;


### PR DESCRIPTION
- Fractional seconds don't have trailing zeros removed
- `strftime` in SQLite defaults to `now`, no need to pass explicitly
- Always (de)serialize time with UTC