### PR TITLE
Don't print log on job success

### DIFF
--- a/jobs/health.go
+++ b/jobs/health.go
@@ -2,12 +2,11 @@ package jobs
 
 import (
 	"context"
-	"log"
 
 	"github.com/maragudk/service/model"
 )
 
-func health(r registry, log *log.Logger) {
+func Health(r registry) {
 	r.Register("health", func(ctx context.Context, m model.Map) error {
 		return nil
 	})

--- a/jobs/register.go
+++ b/jobs/register.go
@@ -1,17 +1,5 @@
 package jobs
 
-import (
-	"sort"
-)
-
 func (r *Runner) registerJobs() {
-	health(r, r.log)
-
-	var names []string
-	for k := range r.jobs {
-		names = append(names, k)
-	}
-	sort.Strings(names)
-
-	r.log.Println("Registered jobs:", names)
+	Health(r)
 }

--- a/jobs/runner.go
+++ b/jobs/runner.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"log"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -96,6 +97,15 @@ type Func = func(context.Context, model.Map) error
 func (r *Runner) Start(ctx context.Context) {
 	r.log.Println("Starting")
 	r.registerJobs()
+
+	var names []string
+	for k := range r.jobs {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	r.log.Println("Registered jobs:", names)
+
 	var wg sync.WaitGroup
 
 	ticker := time.NewTicker(r.pollInterval)
@@ -183,8 +193,6 @@ func (r *Runner) receiveAndRun(ctx context.Context, wg *sync.WaitGroup) {
 			r.log.Println("Error running job:", err)
 			return
 		}
-
-		r.log.Println("Successfully ran job")
 
 		// We use context.Background as the parent context instead of the existing ctx, because if we've come
 		// this far we don't want the deletion to be cancelled.

--- a/jobs/runner_test.go
+++ b/jobs/runner_test.go
@@ -43,8 +43,7 @@ func TestRunner_Start(t *testing.T) {
 		// This blocks until the context is cancelled by the job function
 		runner.Start(ctx)
 
-		require.Equal(t, "Starting\nRegistered jobs: [health test]\nSuccessfully ran job\n"+
-			"Stopping\nStopped\n", logs.String())
+		require.Equal(t, "Starting\nRegistered jobs: [health test]\nStopping\nStopped\n", logs.String())
 	})
 
 	t.Run("emits job metrics", func(t *testing.T) {


### PR DESCRIPTION
Doesn't really add much value that isn't handled by metrics.

Also delegate the registered job logging to the runner itself.