### PR TITLE
Remove conditional in Honeybadger deploy in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,6 @@ jobs:
       - run: flyctl deploy --remote-only
 
       - name: Deploy in Honeybadger
-        if: ${{ secrets.HONEYBADGER_API_KEY != "" }}
         uses: honeybadger-io/github-notify-deploy-action@v1
         with:
           api_key: ${{ secrets.HONEYBADGER_API_KEY }}


### PR DESCRIPTION
Doesn't work, errors with:

```
The workflow is not valid. .github/workflows/cd.yml (Line: 29, Col: 13): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.HONEYBADGER_API_KEY != ""
```