### PR TITLE
Inject PageProps from HTTP handler

### DIFF
--- a/html/home.go
+++ b/html/home.go
@@ -6,9 +6,11 @@ import (
 	. "github.com/maragudk/gomponents/html"
 )
 
-func HomePage() g.Node {
-	return Page(PageProps{Title: "Service", Description: "This is a service."},
+func HomePage(p PageProps) g.Node {
+	p.Title = "Service"
+	p.Description = "This is a service."
 
+	return Page(p,
 		Div(Class("prose-headings:font-serif"),
 			H1(Class("inline-flex items-center"), solid.Sparkles(Class("h-12 w-12 mr-2")), g.Text(`Service`)),
 

--- a/http/pages.go
+++ b/http/pages.go
@@ -12,6 +12,6 @@ import (
 
 func Home(mux chi.Router) {
 	mux.Get("/", ghttp.Adapt(func(w http.ResponseWriter, r *http.Request) (g.Node, error) {
-		return html.HomePage(), nil
+		return html.HomePage(html.PageProps{}), nil
 	}))
 }


### PR DESCRIPTION
This makes it way easier to pass common context to all pages from handlers, such as user auth, base URLs, etc.