### PR TITLE
Add lint timeout of 5 minutes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m


### PR DESCRIPTION
Because the job times out all the time on CI.